### PR TITLE
Batect Command to List all stories; Also run tests in parallel

### DIFF
--- a/Dockerfile.storyshots
+++ b/Dockerfile.storyshots
@@ -14,6 +14,8 @@ COPY storyshots.testStory.ts /storyshots
 COPY storyshots.env.ts /storyshots
 COPY storyshots.executionContext.ts /storyshots
 COPY storyshots.types.ts /storyshots
+COPY storyshots.run.sh /storyshots
+COPY storyshots.update.sh /storyshots
 COPY package.json /storyshots
 COPY pnpm-lock.yaml /storyshots
 
@@ -22,4 +24,4 @@ RUN pnpm install --frozen-lockfile
 
 USER playwright-user
 
-CMD [ "npx", "playwright", "test", "--config=/storyshots/playwright.config.storyshots.ts" ]
+CMD /storyshots/storyshots.run.sh

--- a/Dockerfile.storyshots
+++ b/Dockerfile.storyshots
@@ -6,6 +6,8 @@ RUN chown playwright-user /storyshots
 RUN npm install -g pnpm
 
 COPY playwright.config.storyshots.ts /storyshots
+COPY playwright.config.findStories.ts /storyshots
+COPY storyshots.findStories.ts /storyshots
 COPY storyshots.spec.ts /storyshots
 COPY storyshots.testStories.ts /storyshots
 COPY storyshots.testStory.ts /storyshots

--- a/Dockerfile.storyshots
+++ b/Dockerfile.storyshots
@@ -12,6 +12,7 @@ COPY storyshots.spec.ts /storyshots
 COPY storyshots.testStories.ts /storyshots
 COPY storyshots.testStory.ts /storyshots
 COPY storyshots.env.ts /storyshots
+COPY storyshots.executionContext.ts /storyshots
 COPY storyshots.types.ts /storyshots
 COPY package.json /storyshots
 COPY pnpm-lock.yaml /storyshots

--- a/batect-bundle.yml
+++ b/batect-bundle.yml
@@ -48,3 +48,12 @@ tasks:
     run:
       container: storyshots
       command: npx playwright test --config=/storyshots/playwright.config.storyshots.ts --update-snapshots
+
+  storyshots-list:
+    dependencies:
+      - storybook-server
+    run:
+      container: storyshots
+      environment:
+        STORYSHOTS_LIST: true
+      command: npx playwright test --config=/storyshots/playwright.config.findStories.ts

--- a/batect-bundle.yml
+++ b/batect-bundle.yml
@@ -47,7 +47,7 @@ tasks:
       - storybook-server
     run:
       container: storyshots
-      command: npx playwright test --config=/storyshots/playwright.config.storyshots.ts --update-snapshots
+      command: ./storyshots.update.sh
 
   storyshots-list:
     dependencies:

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "start": "pnpm build && ./batect --override-image storyshots=local-storyshots storyshots",
     "start:single": "pnpm build && STORYSHOTS_STORY=example-button--primary ./batect --override-image storyshots=local-storyshots storyshots",
+    "start:list": "pnpm build && ./batect --override-image storyshots=local-storyshots storyshots-list",
     "start:local": "pnpm build && ./batect --override-image storyshots=local-storyshots --config-vars-file=batect.target-local.yml storyshots",
     "start:update": "pnpm build && ./batect --override-image storyshots=local-storyshots storyshots-update",
     "build": "docker build -t local-storyshots -f Dockerfile.storyshots .",

--- a/playwright.config.findStories.ts
+++ b/playwright.config.findStories.ts
@@ -1,0 +1,34 @@
+import type { PlaywrightTestConfig } from '@playwright/test'
+import { devices } from '@playwright/test'
+
+/** 
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+    testDir: '/storyshots',
+    testMatch: /storyshots.findStories.ts/i,
+    snapshotPathTemplate: '/storyshots/storyshots/{arg}{ext}',
+    timeout: 10 * 1000,
+    expect: {
+        timeout: 5000,
+    },
+    retries: 0,
+    workers: 1,
+    reporter: [['html', { open: 'never' }]],
+    use: {
+        screenshot: 'off',
+        headless: true,
+        baseURL: process.env.STORYBOOK_URL,
+    },
+    projects: [
+        {
+            name: 'chromium',
+            use: {
+                ...devices['Desktop Chrome'],
+                ignoreHTTPSErrors: true,
+            },
+        },
+    ],
+}
+
+export default config

--- a/playwright.config.storyshots.ts
+++ b/playwright.config.storyshots.ts
@@ -13,7 +13,7 @@ const config: PlaywrightTestConfig = {
         timeout: 5000,
     },
     retries: 0,
-    workers: 1,
+    workers: 4,
     reporter: [['html', { open: 'never' }]],
     use: {
         screenshot: 'off',

--- a/spec/bundle_spec.sh
+++ b/spec/bundle_spec.sh
@@ -31,6 +31,10 @@ Describe 'the bundle'
     run_batect storyshots-update spec/batect.ignore.yml
   }
 
+  storyshots_list() {
+    run_batect storyshots-list spec/batect.all.yml
+  }
+
   setup() { 
     reset_repo
     pnpm -F sample build-storybook > /dev/null 2>&1
@@ -40,6 +44,15 @@ Describe 'the bundle'
   AfterAll 'reset_repo'
 
   Describe 'happy paths'
+
+    It 'can list stories to test'
+      When run storyshots_list
+      The output should include '9 stories to test'
+      The output should include '🔘 example-button--primary'
+      The output should include '🔘 example-button--secondary'
+      The stderr should match pattern '*'
+      The status should be success
+    End
 
     It 'can generate a new set of baselines and fail if they do not exist'
       When run storyshots_all

--- a/spec/bundle_spec.sh
+++ b/spec/bundle_spec.sh
@@ -1,4 +1,4 @@
-TEST_RESULTS="test-results-local/test-results/storyshots-visual-regressions-specs-chromium"
+TEST_RESULTS="test-results-local/test-results/storyshots-visual-regressions"
 BATECT_STORYSHOTS="./batect --override-image storyshots=${IMAGE} --config-vars-file spec/batect.test.yml"
 Describe 'the bundle'
 
@@ -56,7 +56,7 @@ Describe 'the bundle'
 
     It 'can generate a new set of baselines and fail if they do not exist'
       When run storyshots_all
-      The output should include '1 failed'
+      The output should include 'failed'
       The output should include '✅ example-button--primary.jpeg'
       The output should include '✅ example-button--secondary.jpeg'
       The stderr should match pattern '*'
@@ -112,11 +112,11 @@ Describe 'the bundle'
 
     It 'can detect when the baseline has deviated and show the diffs'
       When run storyshots_with_ignore
-      The output should include '1 failed'
+      The output should include 'failed'
       The output should include '❌ example-button--primary.jpeg'
       The output should include '✅ example-page--logged-out.jpeg'
       The stderr should match pattern '*'
-      The path ${TEST_RESULTS}/example-button--primary-diff.jpeg should be file
+      The path ${TEST_RESULTS}-example-button--primary-chromium/example-button--primary-diff.jpeg should be file
       The status should be failure
     End
 

--- a/storyshots.env.ts
+++ b/storyshots.env.ts
@@ -5,6 +5,7 @@ import fs from 'fs'
 export interface StoryshotsEnvironment {
     singleStory?: StorybookStory
     ignoreStories: StorybookStory[]
+    listStories?: boolean
 }
 
 interface StoryshotsConfig {
@@ -15,9 +16,14 @@ export function storyshotsEnv(): StoryshotsEnvironment {
     const env: StoryshotsEnvironment = {
         singleStory: undefined,
         ignoreStories: [],
+        listStories: false,
     }
     if (process.env.STORYSHOTS_STORY) {
         env.singleStory = StorybookStory.fromString(process.env.STORYSHOTS_STORY)
+    }
+
+    if (process.env.STORYSHOTS_LIST === 'true') {
+        env.listStories = true
     }
 
     //dynamically import the configuration file from the path '/storyshots/.storyshots.json', if it exists

--- a/storyshots.executionContext.ts
+++ b/storyshots.executionContext.ts
@@ -1,0 +1,21 @@
+import { writeFile } from 'fs/promises'
+import { readFileSync } from 'fs'
+import { StorybookStory } from './storyshots.types'
+
+export class ExecutionContext {
+    setStories = async (storiesList: StorybookStory[]) => {
+        return writeFile(
+            'stories.json',
+            JSON.stringify(storiesList),
+            { encoding: 'utf8' }
+        )
+    }
+    
+    getStories = (): StorybookStory[] => {
+        const stories = readFileSync('stories.json', { encoding: 'utf8' })
+        return JSON.parse(stories)
+            .map((it) => new StorybookStory(it.title, it.target, it.ignore))
+    }
+}
+
+export const executionContext = () => new ExecutionContext()

--- a/storyshots.findStories.ts
+++ b/storyshots.findStories.ts
@@ -1,0 +1,23 @@
+import { test } from '@playwright/test'
+import { testStories } from './storyshots.testStories'
+import * as fs from 'fs/promises'
+import { storyshotsEnv } from './storyshots.env'
+
+const env = storyshotsEnv()
+
+test.describe.only('find stories to test', () => {
+    testStories(env, async (page, storiesList) => {
+        console.log(`${storiesList.length} stories to test`)
+        if (env.listStories) {
+            storiesList.forEach((story) => {
+                console.log(`🔘 ${story.title}`)
+            })
+        }
+
+        return fs.writeFile(
+            'stories.json',
+            JSON.stringify(storiesList, null, 2),
+            { encoding: 'utf8' }
+        )
+    })
+})

--- a/storyshots.findStories.ts
+++ b/storyshots.findStories.ts
@@ -1,9 +1,10 @@
 import { test } from '@playwright/test'
 import { testStories } from './storyshots.testStories'
-import * as fs from 'fs/promises'
 import { storyshotsEnv } from './storyshots.env'
+import { executionContext } from './storyshots.executionContext'
 
 const env = storyshotsEnv()
+const context = executionContext()
 
 test.describe.only('find stories to test', () => {
     testStories(env, async (page, storiesList) => {
@@ -14,10 +15,6 @@ test.describe.only('find stories to test', () => {
             })
         }
 
-        return fs.writeFile(
-            'stories.json',
-            JSON.stringify(storiesList, null, 2),
-            { encoding: 'utf8' }
-        )
+        return context.setStories(storiesList)
     })
 })

--- a/storyshots.run.sh
+++ b/storyshots.run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pnpm exec playwright test --config=/storyshots/playwright.config.findStories.ts
+pnpm exec playwright test --config=/storyshots/playwright.config.storyshots.ts

--- a/storyshots.spec.ts
+++ b/storyshots.spec.ts
@@ -1,19 +1,23 @@
 import { test, expect } from '@playwright/test'
 import { storyshotsEnv } from './storyshots.env'
+import { executionContext } from './storyshots.executionContext'
 import { testStories } from './storyshots.testStories'
 import { testStory } from './storyshots.testStory'
 
 const env = storyshotsEnv()
+const context = executionContext()
 
-test.describe.only('visual regressions', () => {
-    testStories(env, async (page, storiesList) => {
-        let anyStoryFailed = false
-        for (const story of storiesList) {
+
+
+test.describe.only('visual regressions', async () => {
+    const stories = context.getStories()
+
+    stories.forEach((story) => {
+        test(story.title, async ({ page }, testConfig) => {
+            testConfig.snapshotSuffix = ''
             const succeeded = await testStory(page, story)
-            if (!succeeded) {
-                anyStoryFailed = true
-            }
-        }
-        expect(anyStoryFailed, "A visual regression did not pass, review the diffs and either update the baselines or fix the issue").toBe(false)
+
+            expect(succeeded, `Visual regression for ${story.title} did not pass, review the diffs and either update the baselines or fix the issue`).toBe(true)
+        })
     })
 })

--- a/storyshots.spec.ts
+++ b/storyshots.spec.ts
@@ -7,7 +7,7 @@ import { testStory } from './storyshots.testStory'
 const env = storyshotsEnv()
 const context = executionContext()
 
-
+test.describe.configure({ mode: 'parallel' });
 
 test.describe.only('visual regressions', async () => {
     const stories = context.getStories()

--- a/storyshots.update.sh
+++ b/storyshots.update.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pnpm exec playwright test --config=/storyshots/playwright.config.findStories.ts
+pnpm exec playwright test --config=/storyshots/playwright.config.storyshots.ts --update-snapshots


### PR DESCRIPTION
This PR introduces a batect command, `storyshots-list`, which does nothing but list the stories it wants to run. Besides being a potentially useful utility, the point is actually to **prepare for running tests in parallel** and solve #6 .

The idea is that when the storyshots are run, we first run the `findStories` test which just opens the website, identifies all the elements like it does, and stashes them into a file. Then, when the actual spec is run, it reads the file in order to generate a bunch of `test` statements which can be run in parallel.